### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The old Linux kernel source version 0.11 and the integrated experiment environme
     * Build and Start the service
 
                 $ docker build -t tinylab/linux-0.11-lab ./
-                $ CONTAINER_ID=$(docker run -d -p 6080:6080 dorowu/ubuntu-desktop-lxde-vnc)
+                $ CONTAINER_ID=$(docker run -d -p 6080:6080 tinylab/linux-0.11-lab)
                 $ docker logs $CONTAINER_ID | sed -n 1p
                 User: ubuntu Pass: ubuntu
 


### PR DESCRIPTION
Fix script typo in section "Build and Start the service".