### PR TITLE
Allow GCC 5.x to build linux-0.11

### DIFF
--- a/fs/buffer.c
+++ b/fs/buffer.c
@@ -84,7 +84,7 @@ int sync_dev(int dev)
 	return 0;
 }
 
-void inline invalidate_buffers(int dev)
+static inline void invalidate_buffers(int dev)
 {
 	int i;
 	struct buffer_head * bh;

--- a/include/string.h
+++ b/include/string.h
@@ -24,7 +24,7 @@ extern char * strerror(int errno);
  *		(C) 1991 Linus Torvalds
  */
  
-extern inline char * strcpy(char * dest,const char *src)
+static inline char * strcpy(char * dest,const char *src)
 {
 __asm__("cld\n"
 	"1:\tlodsb\n\t"
@@ -51,7 +51,7 @@ __asm__("cld\n"
 return dest;
 }
 
-extern inline char * strcat(char * dest,const char * src)
+static inline char * strcat(char * dest,const char * src)
 {
 __asm__("cld\n\t"
 	"repne\n\t"
@@ -85,7 +85,7 @@ __asm__("cld\n\t"
 return dest;
 }
 
-extern inline int strcmp(const char * cs,const char * ct)
+static inline int strcmp(const char * cs,const char * ct)
 {
 register int __res ;
 __asm__("cld\n"
@@ -158,7 +158,7 @@ __asm__("cld\n\t"
 return __res;
 }
 
-extern inline int strspn(const char * cs, const char * ct)
+static inline int strspn(const char * cs, const char * ct)
 {
 register char * __res;
 __asm__("cld\n\t"
@@ -182,7 +182,7 @@ __asm__("cld\n\t"
 return __res-cs;
 }
 
-extern inline int strcspn(const char * cs, const char * ct)
+static inline int strcspn(const char * cs, const char * ct)
 {
 register char * __res;
 __asm__("cld\n\t"
@@ -206,7 +206,7 @@ __asm__("cld\n\t"
 return __res-cs;
 }
 
-extern inline char * strpbrk(const char * cs,const char * ct)
+static inline char * strpbrk(const char * cs,const char * ct)
 {
 register char * __res ;
 __asm__("cld\n\t"
@@ -233,7 +233,7 @@ __asm__("cld\n\t"
 return __res;
 }
 
-extern inline char * strstr(const char * cs,const char * ct)
+static inline char * strstr(const char * cs,const char * ct)
 {
 register char * __res ;
 __asm__("cld\n\t" \
@@ -260,7 +260,7 @@ __asm__("cld\n\t" \
 return __res;
 }
 
-extern inline int strlen(const char * s)
+static inline int strlen(const char * s)
 {
 register int __res ;
 __asm__("cld\n\t"
@@ -274,7 +274,7 @@ return __res;
 
 extern char * ___strtok;
 
-extern inline char * strtok(char * s,const char * ct)
+static inline char * strtok(char * s,const char * ct)
 {
 register char * __res ;
 __asm__("testl %1,%1\n\t"
@@ -338,7 +338,7 @@ return __res;
  * inline ... it can not be called by other functions in another files.
  */
 
-extern inline void * memcpy(void * dest,const void * src, int n)
+static inline void * memcpy(void * dest,const void * src, int n)
 {
 __asm__ ("cld\n\t"
 	"rep\n\t"
@@ -348,7 +348,7 @@ __asm__ ("cld\n\t"
 return dest;
 }
 
-extern inline void * memmove(void * dest,const void * src, int n)
+static inline void * memmove(void * dest,const void * src, int n)
 {
 if (dest<src)
 __asm__("cld\n\t"
@@ -381,7 +381,7 @@ __asm__("cld\n\t"
 return __res;
 }
 
-extern inline void * memchr(const void * cs,char c,int count)
+static inline void * memchr(const void * cs,char c,int count)
 {
 register void * __res ;
 if (!count)

--- a/kernel/blk_drv/floppy.c
+++ b/kernel/blk_drv/floppy.c
@@ -266,7 +266,7 @@ static void rw_interrupt(void)
 	do_fd_request();
 }
 
-inline void setup_rw_floppy(void)
+extern inline void setup_rw_floppy(void)
 {
 	setup_DMA();
 	do_floppy = rw_interrupt;


### PR DESCRIPTION
GCC 5.x defaults to -std=gnu11 instead of -std=gnu89. While -std=gnu89
employs the GNU89 inline semantics, -std=gnu11 uses the C99 inline
semantics. The C99 inline semantics requires that if a function with
external linkage is declared with inline function specifier, it also has
to be defined in the same translation unit (TU).